### PR TITLE
Update workflow files to upload artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           FILE=$(find build/libs -name "*.jar" | head -n 1)
           echo "asset=$FILE" >> $GITHUB_OUTPUT
       - name: Upload assets
-        uses: softprops/action-gh-release@v2
+        uses: actions/upload-artifact@v4
         with:
-          files: ${{ steps.find_file.outputs.asset }}
-          make_latest: true
+          name: Mod
+          path: ${{ steps.find_file.outputs.asset }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,17 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
+      - name: Find built asset
+        id: find_file
+        run: |
+          FILE=$(find build/libs -name "*.jar" | head -n 1)
+          echo "asset=$FILE" >> $GITHUB_OUTPUT
+      - name: Upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.find_file.outputs.asset }}
+          make_latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    tags:
+      - "*.*.*-*.*.*" # Just reusing the already existing version codes (e.g.: 1.21.1-0.6.0), all that is needed to create a release is to make a new git tag following this format
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1000
+          fetch-tags: true
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+      - name: Find built asset
+        id: find_file
+        run: |
+          FILE=$(find build/libs -name "*.jar" | head -n 1)
+          echo "asset=$FILE" >> $GITHUB_OUTPUT
+      - name: Upload assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: Mod
+          path: ${{ steps.find_file.outputs.asset }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           FILE=$(find build/libs -name "*.jar" | head -n 1)
           echo "asset=$FILE" >> $GITHUB_OUTPUT
       - name: Upload assets
-        uses: actions/upload-artifact@v4
+        uses: softprops/action-gh-release@v2
         with:
-          name: Mod
-          path: ${{ steps.find_file.outputs.asset }}
+          files: ${{ steps.find_file.outputs.asset }}
+          make_latest: true


### PR DESCRIPTION
This PR updates the build.yml workflow to upload the built mod, and also creates a release.yml workflow that creates a github release every time a git tag is created that follows the same format that you made for versioning your mod.

This resolves #12